### PR TITLE
satisfying both readable labels on detailed page and query ui

### DIFF
--- a/map/templates/map/map.html
+++ b/map/templates/map/map.html
@@ -122,8 +122,6 @@
       });
     });
     // END DYNAMIC ELEMENTS ON INFO WINDOW
-
-
   });
   // END SETTING CartoDB
 

--- a/map/templates/map/partials/detail_page.html
+++ b/map/templates/map/partials/detail_page.html
@@ -16,7 +16,7 @@
               {% if datafield.use_for_detail_popup and data_source in datafield.data_sources %}
                 <div class='form-group'>
                   <label for='{{datafield.name}}-field' class='control-label data-label'>{{datafield.label_eng}}</label><br />
-                  <div id='{{datafield.name}}-field' class='data-field' data-choices='{{datafield.choices}}' data-type='{{datafield.type}}'>
+                  <div id='{{datafield.name}}-field' class='data-field' data-choices='{{datafield.choices_str}}' data-type='{{datafield.type}}'>
                     N/A
                   </div>
                 </div>

--- a/map/views.py
+++ b/map/views.py
@@ -38,8 +38,10 @@ def map(request):
       'label_eng': datafield_label_eng,
       # 'label_esp': datafield_label_esp,
       'data_sources': data_sources,
+      # this is object type representation of choices for query ui
       'choices': query_choices,
-      # 'choices': json.dumps(query_choices),# separators=(',', ':'), sort_keys=True),
+      # this is stringified representation of choices for human readable values on detailed page
+      'choices_str': json.dumps(query_choices),# separators=(',', ':'), sort_keys=True),
       'use_for_query_ui': use_for_query_ui,
       'use_for_detail_popup': use_for_detail_popup
     }


### PR DESCRIPTION
As you have noticed before, the detailed popup page and query UIs (select one and select multiple types) had a conflict where only one of them works properly depending on how views.py serializes datafield.choices. If it makes json string, query UI doesn't work. If it serves object itself, detail page doesn't show human-readable values of data.

Now views.py serves both json stringified data and its original object representation for each corresponding feature.
