### PR TITLE
Fix empty details popup

### DIFF
--- a/map/templates/map/map.html
+++ b/map/templates/map/map.html
@@ -370,7 +370,7 @@
 
               $('.link-to-detail').click(function(e) {
                 // Fill out the form
-                // renderDetailPopup(res.rows[0], tableName);
+                renderDetailPopup(res.rows[0], tableName);
 
                 // Make it visible
                 $('.detail-popup').modal('show');


### PR DESCRIPTION
Fix empty details popup: It's unclear if there was a reason for this but we were failing to render the detail popup when the detail popup button is clicked. Instead we were pre-populating it when the leaflet popup appears. This led to the details popup appearing with no contents in cases where it was closed and immediately reopened.