### PR TITLE
Fix Carto HTTPS

### DIFF
--- a/map/templates/map/map.html
+++ b/map/templates/map/map.html
@@ -163,10 +163,12 @@
     app.userName = userName;
 
     cartodb.createLayer(mapObj, {
-      https: true,
       user_name: userName,
       type: layerDef.type,
       sublayers: [layerDef.options]
+    }, 
+    { 
+      https: true
     })
 
     .addTo(mapObj, layerDef.order)


### PR DESCRIPTION
moves the https option into its own set of options-- apparently that's what the library wants.